### PR TITLE
feat: add support for persistent Pixi shells

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def test(s: Session):
 @session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
 def integration(s: Session):
     with s.chdir("tests/integration"):
-        s.run("pixi", "run", "python", "kernel.py", external=True)
+        s.run("pixi", "run", "--manifest-path=pixi.toml", "python", "kernel.py", external=True)
 
 
 @session(venv_backend="none")


### PR DESCRIPTION
https://github.com/prefix-dev/pixi/pull/1080 introduced a feature that allows for a persistent manifest-path when operating within a Pixi shell.
This PR supports this by always passing `--manifest-path` when invoking `pixi`.
@abkfenris in case you want to take a look.
