### PR TITLE
Fallback to blocking `subprocess.run` if using SelectorEventLoop type

### DIFF
--- a/src/pixi_kernel/provisioner.py
+++ b/src/pixi_kernel/provisioner.py
@@ -34,7 +34,7 @@ class PixiKernelProvisioner(LocalProvisioner):  # type: ignore
         logger.info(f"JupyterLab provided this value for cwd: {kwargs.get('cwd', None)}")
         logger.info(f"The current working directory is {cwd}")
 
-        env: dict[str, str] = kwargs.get("env", os.environ)
+        env: dict[str, str] = kwargs.get("env", os.environ.copy())
         pixi_environment = await ensure_readiness(
             cwd=cwd.resolve(),
             env=env,

--- a/tests/unit/test_pixi.py
+++ b/tests/unit/test_pixi.py
@@ -178,8 +178,8 @@ async def test_pyproject_project():
 @pytest.fixture
 async def env_for_pixi_in_pixi():
     cwd = data_dir / "pixi_in_pixi"
-    process, stdout, stderr = await subprocess_exec("pixi", "run", "printenv", cwd=cwd)
-    assert process.returncode == 0, stderr
+    returncode, stdout, stderr = await subprocess_exec("pixi", "run", "printenv", cwd=cwd)
+    assert returncode == 0, stderr
 
     # Update the current environment where the tests are running to merge all the env vars returned
     # by `pixi run env`


### PR DESCRIPTION
Fixes https://github.com/renan-r-santos/pixi-kernel/issues/39